### PR TITLE
chore(ci): prevent semantic-release from pushing to develop branch

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -150,7 +150,6 @@
     ],
     "@semantic-release/github",
     [
-      "@semantic-release/git",
       {
         "assets": [
           "build.gradle",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,7 @@
     "main",
     {
       "name": "develop",
-      "prerelease": true
+      "prerelease": "beta"
     }
   ],
   "plugins": [


### PR DESCRIPTION
### Description

Semantic Release가 develop 브랜치에 직접 git push하지 않도록 releaserc.json을 수정했습니다.
이제 CHANGELOG.md 변경 사항은 GitHub Releases 페이지에서 확인할 수 있으며, develop 브랜치의 보호 규칙을 유지할 수 있습니다.

### Related Issues

- Closes #55 

### Changes Made

1. `@semantic-release/git` 플러그인을 제거하여 develop 브랜치에 직접 push하지 않도록 설정
2. `@semantic-release/github` 플러그인을 유지하여 GitHub Releases에서 변경 내용을 확인 가능하도록 유지
3. `CHANGELOG.md`는 Git에 반영되지 않으며, GitHub Releases 페이지에서 확인 가능

### Screenshots or Video

없음

### Testing

GITHUB_REF 환경 변수를 develop 으로 설정하여 develop 브랜치에서 실행되는 것처럼 테스트 했습니다.


1. `npm install --save-dev @semantic-release/changelog`
2. `GITHUB_REF=refs/heads/develop npx semantic-release --dry-run`
3. 테스트 결과
<img width="1172" alt="스크린샷 2025-03-17 오후 3 31 38" src="https://github.com/user-attachments/assets/56c0da5f-7363-468d-a712-e5d1973e3985" />

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] semantic.yml 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

