### PR TITLE
develop 브랜치에 push 됐을 때 EC2에 자동 배포되는 워크플로우 추가

### DIFF
--- a/.github/workflows/develop-deploy.yml
+++ b/.github/workflows/develop-deploy.yml
@@ -1,0 +1,29 @@
+name: 🚀 Develop 자동 배포
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:  # 수동 실행 가능
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1️⃣ GitHub에서 코드 체크아웃
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      # 2️⃣ AWS EC2 서버에 SSH로 접속하여 자동 배포 스크립트 실행
+      - name: Deploy to AWS EC2
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ubuntu
+            echo "👉 deploy.sh 스크립트 실행 시작"
+            bash deploy.sh
+            echo "✅ 배포 완료" 


### PR DESCRIPTION
### Description

GitHub Actions 워크플로우 파일을 생성했습니다. 이제 develop 브랜치에 코드가 푸시될 때마다 EC2 서버에서 자동으로 deploy.sh 스크립트가 실행됩니다.

### Related Issues

- Resolves #86 
### Changes Made

1. GitHub Actions 워크플로우 YAML 파일 추가
2. EC2 서버 자동 배포를 위한 SSH 접속 및 배포 스크립트 실행 단계 추가
3. GitHub Secrets를 활용하여 EC2 접속 정보 설정

### Screenshots or Video

없음

### Testing

로컬에서 빌드테스트 완료

### Checklist


- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

EC2 배포에 사용된 GitHub Secrets: EC2_HOST, EC2_USER, EC2_SSH_KEY

이 PR 병합 후, 앞으로는 develop 브랜치에 푸시될 때마다 자동으로 배포가 진행됩니다.

