### PR TITLE
feat: 예약 관련 API 및 모델 추가 - 예약 생성, 조회, 상태 변경 및 취소 기능 구현, 관련 DTO 및 예외 처리 추가

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/common/exception/reservation/ReservationNotFoundException.java
+++ b/src/main/java/com/luckeat/luckeatbackend/common/exception/reservation/ReservationNotFoundException.java
@@ -1,0 +1,16 @@
+package com.luckeat.luckeatbackend.common.exception.reservation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ReservationNotFoundException extends RuntimeException {
+    
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+    
+    public ReservationNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/config/SwaggerConfig.java
+++ b/src/main/java/com/luckeat/luckeatbackend/config/SwaggerConfig.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
@@ -25,6 +27,18 @@ public class SwaggerConfig {
                 .bearerFormat("JWT")
                 .in(SecurityScheme.In.HEADER)
                 .name("Authorization");
+        
+        // 공통 응답 정의
+        Components components = new Components()
+                .addSecuritySchemes("jwt", jwtScheme)
+                .addResponses("200", new ApiResponse().description("OK - 요청이 성공적으로 처리되었습니다."))
+                .addResponses("201", new ApiResponse().description("Created - 새 리소스가 성공적으로 생성되었습니다."))
+                .addResponses("400", new ApiResponse().description("Bad Request - 잘못된 요청 또는 유효성 검증 실패"))
+                .addResponses("401", new ApiResponse().description("Unauthorized - 인증되지 않은 사용자"))
+                .addResponses("403", new ApiResponse().description("Forbidden - 접근 권한이 없습니다."))
+                .addResponses("404", new ApiResponse().description("Not Found - 요청한 리소스를 찾을 수 없습니다."))
+                .addResponses("409", new ApiResponse().description("Conflict - 리소스 충돌 (예: 중복된 데이터)"))
+                .addResponses("500", new ApiResponse().description("Internal Server Error - 서버 오류가 발생했습니다."));
                 
         // API 정보 설정과 시큐리티 스키마 등록
         return new OpenAPI()
@@ -32,7 +46,7 @@ public class SwaggerConfig {
                         .title("LuckEat API")
                         .description("LuckEat 백엔드 API 문서")
                         .version("v1.0.0"))
-                .components(new Components().addSecuritySchemes("jwt", jwtScheme))
+                .components(components)
                 .addSecurityItem(new SecurityRequirement().addList("jwt"))
                 .servers(List.of(new Server().url("/").description("현재 서버")));
     }

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/controller/ReservationController.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/controller/ReservationController.java
@@ -1,0 +1,116 @@
+package com.luckeat.luckeatbackend.reservation.controller;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.luckeat.luckeatbackend.reservation.dto.ReservationRequestDto;
+import com.luckeat.luckeatbackend.reservation.dto.ReservationResponseDto;
+import com.luckeat.luckeatbackend.reservation.dto.ReservationStatusRequestDto;
+import com.luckeat.luckeatbackend.reservation.service.ReservationService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 예약 관련 API를 처리하는 컨트롤러
+ * 예약 생성, 조회, 상태 변경, 취소 등의 기능 제공
+ */
+@RestController
+@RequestMapping("api/v1/reservation")
+@RequiredArgsConstructor
+@Tag(name = "예약 API", description = "예약 관련 API")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+    
+    /**
+     * 새로운 예약을 생성합니다.
+     * 
+     * @param storeId 가게 ID
+     * @param requestDto 예약 생성 정보 (상품ID, 수량, 제로웨이스트 여부)
+     * @return 생성된 예약 정보와 201 Created 상태 코드
+     */
+    @Operation(summary = "예약 생성", description = "새로운 예약을 생성합니다.")
+    @PostMapping("/stores/{storeId}")
+    public ResponseEntity<ReservationResponseDto> createReservation(
+            @Parameter(name = "storeId", description = "가게 ID", required = true, in = ParameterIn.PATH) 
+            @PathVariable Long storeId,
+            @Valid @RequestBody ReservationRequestDto requestDto) {
+        ReservationResponseDto responseDto = reservationService.createReservation(storeId, requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    }
+    
+    /**
+     * 예약 상태를 변경합니다 (확정 또는 취소).
+     * 가게 소유자는 PENDING → CONFIRMED 상태로 변경할 수 있습니다.
+     * 고객과 가게 소유자 모두 예약을 CANCELED 상태로 변경(취소)할 수 있습니다.
+     * 
+     * @param requestDto 예약 상태 변경 정보 (예약ID, 변경할 상태)
+     * @return 변경된 예약 정보
+     */
+    @Operation(summary = "예약 상태 변경/취소", description = "예약 상태를 변경합니다. 상태 값으로 CONFIRMED 또는 CANCELED를 사용할 수 있습니다.")
+    @PostMapping("/status")
+    public ResponseEntity<ReservationResponseDto> updateReservationStatus(
+            @Valid @RequestBody ReservationStatusRequestDto requestDto) {
+        ReservationResponseDto updatedReservation = reservationService.updateReservationStatus(
+                requestDto.getReservationId(), requestDto.getStatus());
+        return ResponseEntity.ok(updatedReservation);
+    }
+    
+    /**
+     * 특정 가게의 모든 예약을 조회합니다 (가게 소유자용).
+     * 
+     * @param storeId 가게 ID
+     * @return 해당 가게의 모든 예약 목록
+     */
+    @Operation(summary = "가게 전체 예약 목록 조회", description = "특정 가게의 모든 예약을 조회합니다. (가게 소유자용)")
+    @GetMapping("/stores/{storeId}")
+    public ResponseEntity<List<ReservationResponseDto>> getStoreReservations(
+            @Parameter(name = "storeId", description = "가게 ID", required = true, in = ParameterIn.PATH) 
+            @PathVariable Long storeId) {
+        List<ReservationResponseDto> reservations = reservationService.getStoreReservations(storeId);
+        return ResponseEntity.ok(reservations);
+    }
+    
+    /**
+     * 특정 가게의 대기중(PENDING) 예약을 조회합니다 (가게 소유자용).
+     * 
+     * @param storeId 가게 ID
+     * @return 해당 가게의 대기중인 예약 목록
+     */
+    @Operation(summary = "가게 대기중 예약 목록 조회", description = "특정 가게의 대기중(PENDING) 예약을 조회합니다. (가게 소유자용)")
+    @GetMapping("/stores/pending/{storeId}")
+    public ResponseEntity<List<ReservationResponseDto>> getStorePendingReservations(
+            @Parameter(name = "storeId", description = "가게 ID", required = true, in = ParameterIn.PATH) 
+            @PathVariable Long storeId) {
+        List<ReservationResponseDto> pendingReservations = reservationService.getStorePendingReservations(storeId);
+        return ResponseEntity.ok(pendingReservations);
+    }
+    
+    /**
+     * 특정 고객의 모든 예약을 조회합니다.
+     * 
+     * @param userId 사용자 ID
+     * @return 해당 사용자의 모든 예약 목록
+     */
+    @Operation(summary = "고객 예약 목록 조회", description = "특정 고객의 모든 예약을 조회합니다.")
+    @GetMapping("/{userId}")
+    public ResponseEntity<List<ReservationResponseDto>> getUserReservations(
+            @Parameter(name = "userId", description = "사용자 ID", required = true, in = ParameterIn.PATH) 
+            @PathVariable Long userId) {
+        List<ReservationResponseDto> userReservations = reservationService.getUserReservationsById(userId);
+        return ResponseEntity.ok(userReservations);
+    }
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationRequestDto.java
@@ -1,0 +1,56 @@
+package com.luckeat.luckeatbackend.reservation.dto;
+
+import com.luckeat.luckeatbackend.product.model.Product;
+import com.luckeat.luckeatbackend.reservation.model.Reservation;
+import com.luckeat.luckeatbackend.reservation.model.Reservation.ReservationStatus;
+import com.luckeat.luckeatbackend.store.model.Store;
+import com.luckeat.luckeatbackend.users.model.User;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "예약 생성 요청 DTO")
+public class ReservationRequestDto {
+    
+    @Schema(description = "상품 ID", example = "1")
+    @NotNull(message = "상품 ID는 필수입니다.")
+    private Long productId;
+    
+    @Schema(description = "예약 수량", example = "2")
+    @NotNull(message = "수량은 필수입니다.")
+    @Min(value = 1, message = "수량은 최소 1개 이상이어야 합니다.")
+    private Long quantity;
+    
+    @Schema(description = "제로웨이스트 여부", example = "true")
+    @NotNull(message = "제로웨이스트 여부는 필수입니다.")
+    private Boolean isZerowaste;
+    
+    public Reservation toEntity(User user, Store store, Product product) {
+        Long totalPrice = calculateTotalPrice(product, quantity);
+        
+        return Reservation.builder()
+                .user(user)
+                .store(store)
+                .product(product)
+                .quantity(quantity)
+                .totalPrice(totalPrice)
+                .status(ReservationStatus.PENDING)
+                .isZerowaste(isZerowaste)
+                .build();
+    }
+    
+    private Long calculateTotalPrice(Product product, Long quantity) {
+        return product.getDiscountedPrice() * quantity;
+    }
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationResponseDto.java
@@ -1,0 +1,71 @@
+package com.luckeat.luckeatbackend.reservation.dto;
+
+import java.time.LocalDateTime;
+
+import com.luckeat.luckeatbackend.reservation.model.Reservation;
+import com.luckeat.luckeatbackend.reservation.model.Reservation.ReservationStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "예약 응답 DTO")
+public class ReservationResponseDto {
+
+    @Schema(description = "예약 ID")
+    private Long id;
+    
+    @Schema(description = "사용자 ID")
+    private Long userId;
+    
+    @Schema(description = "가게 ID")
+    private Long storeId;
+    
+    @Schema(description = "상품 ID")
+    private Long productId;
+    
+    @Schema(description = "가게 이름")
+    private String storeName;
+    
+    @Schema(description = "상품 이름")
+    private String productName;
+    
+    @Schema(description = "수량")
+    private Long quantity;
+    
+    @Schema(description = "총 금액")
+    private Long totalPrice;
+    
+    @Schema(description = "예약 상태")
+    private ReservationStatus status;
+    
+    @Schema(description = "제로웨이스트 여부")
+    private Boolean isZerowaste;
+    
+    @Schema(description = "생성 시간")
+    private LocalDateTime createdAt;
+    
+    public static ReservationResponseDto fromEntity(Reservation reservation) {
+        return ReservationResponseDto.builder()
+                .id(reservation.getId())
+                .userId(reservation.getUser().getId())
+                .storeId(reservation.getStore().getId())
+                .productId(reservation.getProduct().getId())
+                .storeName(reservation.getStore().getStoreName())
+                .productName(reservation.getProduct().getProductName())
+                .quantity(reservation.getQuantity())
+                .totalPrice(reservation.getTotalPrice())
+                .status(reservation.getStatus())
+                .isZerowaste(reservation.getIsZerowaste())
+                .createdAt(reservation.getCreatedAt())
+                .build();
+    }
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationStatusRequestDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationStatusRequestDto.java
@@ -1,0 +1,28 @@
+package com.luckeat.luckeatbackend.reservation.dto;
+
+import com.luckeat.luckeatbackend.reservation.model.Reservation.ReservationStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "예약 상태 변경 요청 DTO")
+public class ReservationStatusRequestDto {
+    
+    @Schema(description = "예약 ID", example = "1")
+    @NotNull(message = "예약 ID는 필수입니다.")
+    private Long reservationId;
+    
+    @Schema(description = "변경할 상태 (CONFIRMED 또는 CANCELED)", example = "CONFIRMED")
+    @NotNull(message = "변경할 상태는 필수입니다.")
+    private ReservationStatus status;
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/model/Reservation.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/model/Reservation.java
@@ -1,0 +1,67 @@
+package com.luckeat.luckeatbackend.reservation.model;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.SQLDelete;
+
+import com.luckeat.luckeatbackend.common.entity.BaseEntity;
+import com.luckeat.luckeatbackend.product.model.Product;
+import com.luckeat.luckeatbackend.store.model.Store;
+import com.luckeat.luckeatbackend.users.model.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "reservation")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@SQLDelete(sql = "UPDATE reservation SET deleted_at = NOW() WHERE id = ?")
+public class Reservation extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(name = "quantity", nullable = false, columnDefinition = "BIGINT UNSIGNED COMMENT '예약 수량'")
+    private Long quantity;
+
+    @Column(name = "total_price", nullable = false, columnDefinition = "BIGINT UNSIGNED COMMENT '총 가격'")
+    private Long totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, columnDefinition = "ENUM('PENDING', 'CONFIRMED', 'CANCELED') COMMENT '예약 상태'")
+    private ReservationStatus status;
+
+    @Column(name = "is_zerowaste", nullable = false, columnDefinition = "BOOLEAN COMMENT '제로웨이스트 여부'")
+    private Boolean isZerowaste;
+
+    public enum ReservationStatus {
+        PENDING, CONFIRMED, CANCELED //COMPLETED
+    }
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/repository/ReservationRepository.java
@@ -1,0 +1,36 @@
+package com.luckeat.luckeatbackend.reservation.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.luckeat.luckeatbackend.reservation.model.Reservation;
+import com.luckeat.luckeatbackend.reservation.model.Reservation.ReservationStatus;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    
+    List<Reservation> findByUserId(Long userId);
+    
+    List<Reservation> findByStoreId(Long storeId);
+    
+    List<Reservation> findByProductId(Long productId);
+    
+    List<Reservation> findByStoreIdAndStatus(Long storeId, ReservationStatus status);
+    
+    List<Reservation> findByUserIdAndDeletedAtIsNull(Long userId);
+    
+    List<Reservation> findByStoreIdAndDeletedAtIsNull(Long storeId);
+    
+    List<Reservation> findByStoreIdAndStatusAndDeletedAtIsNull(Long storeId, ReservationStatus status);
+    
+    Optional<Reservation> findByIdAndUserId(Long id, Long userId);
+    
+    Optional<Reservation> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+    
+    Optional<Reservation> findByIdAndDeletedAtIsNull(Long id);
+    
+    List<Reservation> findByDeletedAtIsNull();
+} 

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
@@ -1,0 +1,193 @@
+package com.luckeat.luckeatbackend.reservation.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.luckeat.luckeatbackend.common.exception.product.ProductNotFoundException;
+import com.luckeat.luckeatbackend.common.exception.reservation.ReservationNotFoundException;
+import com.luckeat.luckeatbackend.common.exception.store.StoreNotFoundException;
+import com.luckeat.luckeatbackend.common.exception.user.UserNotFoundException;
+import com.luckeat.luckeatbackend.product.model.Product;
+import com.luckeat.luckeatbackend.product.repository.ProductRepository;
+import com.luckeat.luckeatbackend.reservation.dto.ReservationRequestDto;
+import com.luckeat.luckeatbackend.reservation.dto.ReservationResponseDto;
+import com.luckeat.luckeatbackend.reservation.model.Reservation;
+import com.luckeat.luckeatbackend.reservation.model.Reservation.ReservationStatus;
+import com.luckeat.luckeatbackend.reservation.repository.ReservationRepository;
+import com.luckeat.luckeatbackend.store.model.Store;
+import com.luckeat.luckeatbackend.store.repository.StoreRepository;
+import com.luckeat.luckeatbackend.users.model.User;
+import com.luckeat.luckeatbackend.users.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+    
+    /**
+     * 새로운 예약 생성
+     */
+    @Transactional
+    public ReservationResponseDto createReservation(Long storeId, ReservationRequestDto requestDto) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+        
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreNotFoundException("가게를 찾을 수 없습니다."));
+        
+        Product product = productRepository.findById(requestDto.getProductId())
+                .orElseThrow(() -> new ProductNotFoundException("상품을 찾을 수 없습니다."));
+        
+        // 상품이 해당 가게의 것인지 확인
+        if (!product.getStore().getId().equals(storeId)) {
+            throw new ProductNotFoundException("해당 가게의 상품이 아닙니다.");
+        }
+        
+        Reservation reservation = requestDto.toEntity(user, store, product);
+        Reservation savedReservation = reservationRepository.save(reservation);
+        
+        return ReservationResponseDto.fromEntity(savedReservation);
+    }
+    
+    /**
+     * 사용자의 모든 예약 조회 (ID로 조회)
+     */
+    @Transactional(readOnly = true)
+    public List<ReservationResponseDto> getUserReservationsById(Long userId) {
+        // 사용자 권한 확인 로직 추가 필요 
+        // (현재 로그인한 사용자가 요청한 userId와 동일한지 또는 관리자인지)
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        List<Reservation> reservations = reservationRepository.findByUserIdAndDeletedAtIsNull(userId);
+        
+        return reservations.stream()
+                .map(ReservationResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 가게의 모든 예약 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ReservationResponseDto> getStoreReservations(Long storeId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+        
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreNotFoundException("가게를 찾을 수 없습니다."));
+        
+        // 가게 소유자 확인 로직 추가 필요
+        
+        List<Reservation> reservations = reservationRepository.findByStoreIdAndDeletedAtIsNull(storeId);
+        
+        return reservations.stream()
+                .map(ReservationResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 가게의 대기중(PENDING) 예약 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ReservationResponseDto> getStorePendingReservations(Long storeId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+        
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreNotFoundException("가게를 찾을 수 없습니다."));
+        
+        // 가게 소유자 확인 로직 추가 필요
+        
+        List<Reservation> reservations = reservationRepository.findByStoreIdAndStatusAndDeletedAtIsNull(
+                storeId, ReservationStatus.PENDING);
+        
+        return reservations.stream()
+                .map(ReservationResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * 예약 상태 변경
+     * 가게 소유자는 PENDING → CONFIRMED로 변경 가능
+     * 사용자와 가게 소유자 모두 CANCELED 상태로 변경 가능
+     */
+    @Transactional
+    public ReservationResponseDto updateReservationStatus(Long reservationId, ReservationStatus status) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+        
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        Reservation reservation = reservationRepository.findByIdAndDeletedAtIsNull(reservationId)
+                .orElseThrow(() -> new ReservationNotFoundException("예약을 찾을 수 없습니다."));
+        
+        // 사용자 권한 체크
+        boolean isStoreOwner = reservation.getStore().getUserId().equals(user.getId());
+        boolean isReservationUser = reservation.getUser().getId().equals(user.getId());
+        
+        // 권한 검증
+        if (status == ReservationStatus.CONFIRMED) {
+            // CONFIRMED는 가게 소유자만 가능
+            if (!isStoreOwner) {
+                throw new SecurityException("예약 상태를 변경할 권한이 없습니다.");
+            }
+        } else if (status == ReservationStatus.CANCELED) {
+            // CANCELED는 예약자 본인 또는 가게 소유자만 가능
+            if (!isReservationUser && !isStoreOwner) {
+                throw new SecurityException("예약을 취소할 권한이 없습니다.");
+            }
+            
+            // CANCELED 상태로 변경될 때 deleted_at 필드에 현재 시간 설정
+            reservation.setDeletedAt(LocalDateTime.now());
+        } else {
+            throw new IllegalArgumentException("유효하지 않은 예약 상태입니다.");
+        }
+        
+        reservation.setStatus(status);
+        Reservation updatedReservation = reservationRepository.save(reservation);
+        
+        return ReservationResponseDto.fromEntity(updatedReservation);
+    }
+    
+    /**
+     * 예약 삭제 (소프트 딜리트)
+     */
+    @Transactional
+    public void deleteReservation(Long reservationId) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String userEmail = authentication.getName();
+        
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다."));
+        
+        Reservation reservation = reservationRepository.findByIdAndUserIdAndDeletedAtIsNull(reservationId, user.getId())
+                .orElseThrow(() -> new ReservationNotFoundException("예약을 찾을 수 없습니다."));
+        
+        reservation.setDeletedAt(LocalDateTime.now());
+        reservationRepository.save(reservation);
+    }
+} 


### PR DESCRIPTION
### Description

- 예약 생성, 조회, 상태 변경 및 취소 기능 구현

[상태 변경] - 세부사항
- CONFIRMED 상태 변경: 가게 소유자만 가능
- CANCELED 상태 변경: 예약자 본인 또는 가게 소유자만 가능
- 예약 취소(CANCELED 상태 변경) 시 자동으로 deleted_at 필드에 현재 시간 설정


### Related Issues

- Resolves #139 


### Testing

스웨거를 통해 모든 api 테스트 완료

[예약생성]
<img width="951" alt="예약생성" src="https://github.com/user-attachments/assets/0ce14667-884e-4fa7-920f-b43ff5520e23" />

[가게별 status가 pending인 예약만]
<img width="1016" alt="가게 팬딩중만" src="https://github.com/user-attachments/assets/21165723-6b6a-4c12-82fb-6cdbc7eb516a" />

[예약 상태 변경]
<img width="948" alt="예약 상태 변경" src="https://github.com/user-attachments/assets/4b5e2b5f-be27-4d68-9e7d-1d31ffc79d02" />

[유저ID로 예약조회]
<img width="950" alt="유저ID로 예약조회" src="https://github.com/user-attachments/assets/fedde03a-5d81-45b7-8c49-aae3e9615c38" />


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

