### PR TITLE
예약 취소 후 재고가 0이상 일때 상품의 isOpen 상태를 true로 변경하는 로직 추가

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
@@ -197,7 +197,14 @@ public class ReservationService {
 
             // 재고 증가 처리
             Product product = reservation.getProduct();
-            product.increaseStock(reservation.getQuantity().intValue());
+            int quantity = reservation.getQuantity().intValue();
+            
+            // 현재 재고가 0이고, 취소된 수량이 0보다 크다면 isOpen을 true로 변경
+            if (product.getProductCount() == 0 && quantity > 0) {
+                product.setIsOpen(true);
+            }
+            
+            product.increaseStock(quantity);
             
             // 예약 취소 처리
             reservation.setStatus(status);


### PR DESCRIPTION
### Description

예약 취소 후 재고가 0이상 일때 상품의 isOpen 상태를 true로 변경하는 로직 추가

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Closes #173 

### Changes Made

예약 취소 후 재고가 0이상 일때 상품의 isOpen 상태를 true로 변경하는 로직 추가


### Testing

스웨거로 테스트

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.


