### PR TITLE
예약 관련 DTO 및 모델에 리뷰 작성 여부 필드를 추가하고, 예약 서비스에 예약 업데이트 메서드를 구현

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationRequestDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationRequestDto.java
@@ -36,6 +36,9 @@ public class ReservationRequestDto {
     @NotNull(message = "제로웨이스트 여부는 필수입니다.")
     private Boolean isZerowaste;
     
+    @Schema(description = "리뷰 작성 여부", example = "false")
+    private Boolean isReviewed;
+    
     public Reservation toEntity(User user, Store store, Product product) {
         Long totalPrice = calculateTotalPrice(product, quantity);
         
@@ -47,6 +50,7 @@ public class ReservationRequestDto {
                 .totalPrice(totalPrice)
                 .status(ReservationStatus.PENDING)
                 .isZerowaste(isZerowaste)
+                .isReviewed(isReviewed != null ? isReviewed : false)
                 .build();
     }
     

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationResponseDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/dto/ReservationResponseDto.java
@@ -53,6 +53,9 @@ public class ReservationResponseDto {
     @Schema(description = "제로웨이스트 여부")
     private Boolean isZerowaste;
     
+    @Schema(description = "리뷰 작성 여부")
+    private Boolean isReviewed;
+    
     @Schema(description = "생성 시간")
     private LocalDateTime createdAt;
     
@@ -69,6 +72,7 @@ public class ReservationResponseDto {
                 .totalPrice(reservation.getTotalPrice())
                 .status(reservation.getStatus())
                 .isZerowaste(reservation.getIsZerowaste())
+                .isReviewed(reservation.getIsReviewed())
                 .createdAt(reservation.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/model/Reservation.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/model/Reservation.java
@@ -61,6 +61,9 @@ public class Reservation extends BaseEntity {
     @Column(name = "is_zerowaste", nullable = false, columnDefinition = "BOOLEAN COMMENT '제로웨이스트 여부'")
     private Boolean isZerowaste;
 
+    @Column(name = "is_reviewed", nullable = false, columnDefinition = "BOOLEAN COMMENT '리뷰 작성 여부'")
+    private Boolean isReviewed;
+
     public enum ReservationStatus {
         PENDING, CONFIRMED, CANCELED //COMPLETED
     }

--- a/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/reservation/service/ReservationService.java
@@ -240,4 +240,9 @@ public class ReservationService {
         return reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ReservationNotFoundException("예약을 찾을 수 없습니다."));
     }
+    
+    @Transactional
+    public Reservation updateReservation(Reservation reservation) {
+        return reservationRepository.save(reservation);
+    }
 } 

--- a/src/main/java/com/luckeat/luckeatbackend/review/service/ReviewService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/review/service/ReviewService.java
@@ -111,6 +111,10 @@ public class ReviewService {
 		
 		reviewRepository.save(review);
 		updateStoreAverageRating(requestDto.getStoreId());
+		
+		// 예약의 isReviewed 필드를 true로 업데이트
+		reservation.setIsReviewed(true);
+		reservationService.updateReservation(reservation);
 	}
 
 	@Transactional


### PR DESCRIPTION
### Description

reservation 테이블에 is_reviewed 컬럼을 추가
Reservation 엔티티에 isReviewed 필드를 추가
ReservationRequestDto와 ReservationResponseDto에 isReviewed 필드
ReviewService에서 리뷰 생성 시 예약의 isReviewed 필드를 true로 업데이트하도록 수정
ReservationService에 updateReservation 메서드를 추가

### Related Issues

- closes #189 


### Testing

크롬에서 테스트 완료


### Checklist


- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

