### PR TITLE
회원가입 로직 개선 및 상품 재고에 비관적락 적용

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/product/model/Product.java
+++ b/src/main/java/com/luckeat/luckeatbackend/product/model/Product.java
@@ -50,41 +50,5 @@ public class Product extends BaseEntity {
 
     @Column(name = "is_open", nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE COMMENT '상품 판매 여부'")
     private Boolean isOpen = true;
-
-
-	 public void decreaseStock(int quantity) {
-        validateDecreaseStockQuantity(quantity);
-        this.productCount -= quantity;
-        
-        // 재고가 0이 되면 isOpen을 false로 변경
-        if (this.productCount == 0) {
-            this.isOpen = false;
-        }
-    }
-
-    public void increaseStock(int quantity) {
-        validateIncreaseStockQuantity(quantity);
-        this.productCount += quantity;
-    }
-    
-    private void validateDecreaseStockQuantity(int quantity) {
-        if (quantity < 0) {
-            throw new IllegalArgumentException("수량은 0보다 작을 수 없습니다.");
-        }
-        
-        if (this.productCount < quantity) {
-            throw new IllegalStateException("재고가 부족합니다. 현재 재고: " + this.productCount);
-        }
-    }
-    
-    private void validateIncreaseStockQuantity(int quantity) {
-        if (quantity < 0) {
-            throw new IllegalArgumentException("수량은 0보다 작을 수 없습니다.");
-        }
-        
-        // 필요한 경우 최대 재고 제한을 추가할 수 있습니다
-        if (this.productCount + quantity > Integer.MAX_VALUE) {
-            throw new IllegalStateException("재고 최대치를 초과할 수 없습니다.");
-        }
-    }
+	
 }

--- a/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
+++ b/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
@@ -46,11 +46,12 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findByIdWithPessimisticLock(@Param("id") Long id);
 
 	@Modifying
-   	@Query("UPDATE Product p SET p.productCount = CASE WHEN p.productCount < :quantity THEN p.productCount ELSE p.productCount - :quantity END, " +
-           "p.isOpen = CASE WHEN p.productCount <= :quantity THEN false ELSE p.isOpen END " +
-           "WHERE p.id = :productId")
-    int decreaseProductStock(@Param("productId") Long productId, @Param("quantity") int quantity);
-
+	@Query("UPDATE Product p SET " +
+		"p.productCount = CASE WHEN p.productCount >= :quantity THEN p.productCount - :quantity ELSE p.productCount END, " +
+		"p.isOpen = CASE WHEN p.productCount >= :quantity AND (p.productCount - :quantity) = 0 THEN false ELSE p.isOpen END " +
+		"WHERE p.id = :productId AND p.productCount >= :quantity")
+	int decreaseProductStock(@Param("productId") Long productId, @Param("quantity") int quantity);
+	
 	@Modifying
 	@Query("UPDATE Product p SET p.productCount = p.productCount + :quantity, " +
 		"p.isOpen = CASE WHEN p.productCount + :quantity > 0 THEN true ELSE p.isOpen END " +

--- a/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
+++ b/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
@@ -4,10 +4,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.luckeat.luckeatbackend.product.model.Product;
 import com.luckeat.luckeatbackend.store.model.Store;
+
+import jakarta.persistence.LockModeType;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
@@ -23,6 +29,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
 	Optional<Product> findByIdAndStoreAndDeletedAtIsNull(Long id, Store store);
 
+	Optional<Product> findByIdAndDeletedAtIsNull(Long id);
+
 	Optional<Product> findByIdAndStoreAndProductCountGreaterThan(Long id, Store store, Long count);
 	// 특정 가게의 마감할인 중인 상품 개수 조회
 	// 삭제되지 않은 상품 중에서 마감할인 중인 상품 개수 조회
@@ -32,4 +40,21 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     boolean existsByStoreIdAndIsOpenTrueAndDeletedAtIsNull(Long storeId);
 
     boolean existsByStoreIdAndDeletedAtIsNull(Long storeId);
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdWithPessimisticLock(@Param("id") Long id);
+
+	@Modifying
+   	@Query("UPDATE Product p SET p.productCount = CASE WHEN p.productCount < :quantity THEN p.productCount ELSE p.productCount - :quantity END, " +
+           "p.isOpen = CASE WHEN p.productCount <= :quantity THEN false ELSE p.isOpen END " +
+           "WHERE p.id = :productId")
+    int decreaseProductStock(@Param("productId") Long productId, @Param("quantity") int quantity);
+
+	@Modifying
+	@Query("UPDATE Product p SET p.productCount = p.productCount + :quantity, " +
+		"p.isOpen = CASE WHEN p.productCount + :quantity > 0 THEN true ELSE p.isOpen END " +
+		"WHERE p.id = :productId")
+	int increaseProductStock(@Param("productId") Long productId, @Param("quantity") int quantity);
+
 }

--- a/src/main/java/com/luckeat/luckeatbackend/users/service/UserService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/users/service/UserService.java
@@ -60,20 +60,24 @@ public class UserService {
 		return userRepository.findByNicknameAndDeletedAtIsNull(nickname);
 	}
 
-	// DTO를 받아서 User를 생성하는 메소드
+
+	// 기존 메소드도 유지 (하위 호환성을 위해)
 	@Transactional
 	public User createUser(RegisterRequestDto registerDto) {
-		// 이메일 중복 검사
-		if (userRepository.existsByEmailAndDeletedAtIsNull(registerDto.getEmail())) {
+
+		// 이메일 중복 검사 - 소프트 삭제된 사용자의 이메일도 중복 체크에 포함
+		if (userRepository.existsByEmail(registerDto.getEmail())) {
 			throw new EmailDuplicateException();
 		}
-		
-		// 닉네임 중복 검사
-		if (userRepository.existsByNicknameAndDeletedAtIsNull(registerDto.getNickname())) {
+
+
+		// 닉네임 중복 검사 - 소프트 삭제된 사용자의 닉네임도 중복 체크에 포함
+		if (userRepository.existsByNickname(registerDto.getNickname())) {
 			throw new NicknameDuplicateException();
 		}
 		
-		// User 객체 생성
+		
+		// 비밀번호 암호화
 		User user = User.builder()
 				.email(registerDto.getEmail())
 				.nickname(registerDto.getNickname())
@@ -81,26 +85,6 @@ public class UserService {
 				.role(User.Role.valueOf(registerDto.getRole().name()))
 				.build();
 		
-		return userRepository.save(user);
-	}
-
-	// 기존 메소드도 유지 (하위 호환성을 위해)
-	@Transactional
-	public User createUser(User user) {
-
-		// 이메일 중복 검사 - 소프트 삭제된 사용자의 이메일도 중복 체크에 포함
-		if (userRepository.existsByEmail(user.getEmail())) {
-			throw new EmailDuplicateException();
-		}
-
-		// 닉네임 중복 검사 - 소프트 삭제된 사용자의 닉네임도 중복 체크에 포함
-		if (userRepository.existsByNickname(user.getNickname())) {
-			throw new NicknameDuplicateException();
-		}
-		
-		
-		// 비밀번호 암호화
-		user.setPassword(passwordEncoder.encode(user.getPassword()));
 		return userRepository.save(user);
 	}
 


### PR DESCRIPTION
### Description

회원 탈퇴시 같은 이메일로 재가입 되는 문제 개선
상품 재고에 비관적 락 적용

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Closes #188
- Closes #191

### Changes Made


1. 회원 탈퇴시 같은 이메일과 닉네임으로 재가입 불가능하게 변경
2. 상품 재고에 비관적 락 적용

### Testing

스웨거와 터미널로 테스트


### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.


