### PR TITLE
제품 재고 감소 쿼리 수정 - 제품 수량이 정확히 일치할 때 is_open 필드 업데이트 로직 변경

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
+++ b/src/main/java/com/luckeat/luckeatbackend/product/repository/ProductRepository.java
@@ -47,8 +47,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
 	@Modifying
 	@Query(value = "UPDATE product SET " +
-		"product_count = product_count - :quantity, " +
-		"is_open = CASE WHEN product_count <= :quantity THEN 0 ELSE is_open END " +
+		"is_open = CASE WHEN product_count = :quantity THEN false ELSE is_open END, " +
+		"product_count = product_count - :quantity " +
 		"WHERE id = :productId AND product_count >= :quantity", 
 		nativeQuery = true)
 	int decreaseProductStock(@Param("productId") Long productId, @Param("quantity") int quantity);


### PR DESCRIPTION
### Description

제품 재고 감소 쿼리 수정 - 제품 수량이 정확히 일치할 때 is_open 필드 업데이트 로직 변경

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Closes #224

### Changes Made

<!--
  이 PR에서 변경된 사항을 설명하세요.
  코드, 문서, 설정 등 변경된 내용을 상세히 기술합니다.
-->

1. 재고가 1개 이상 남으면 isOpen true로 변경
2. 재가고 0개 되는 순간 isOpen false로 변경




### Testing

스웨거로 테스트

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.



