### PR TITLE
PasswordUpdateDto에서 현재 비밀번호의 패턴 검사를 제거함

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/users/dto/PasswordUpdateDto.java
+++ b/src/main/java/com/luckeat/luckeatbackend/users/dto/PasswordUpdateDto.java
@@ -15,8 +15,6 @@ import lombok.NoArgsConstructor;
 public class PasswordUpdateDto {
 
 	@NotBlank(message = "현재 비밀번호는 필수 입력 항목입니다.")
-	@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,20}$", 
-			message = "비밀번호는 영문자와 숫자를 모두 포함해야 합니다.")
 	@Schema(description = "현재 비밀번호", example = "currentPassword123", required = true)
 	private String currentPassword;
 	


### PR DESCRIPTION
### Description

현재 비밀번호는 처음에 유효성 검사를 통과했기때문에 영
PasswordUpdateDto에서 현재 비밀번호의 패턴 검사를 제거함

### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Closes #214

### Changes Made


1. PasswordUpdateDto에서 현재 비밀번호 관련 유효성 검사를 제거함


### Testing

로컬 환경에서 테스트

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.


