### PR TITLE
refactor(cache): Redis 캐시 설정에서 불필요한 타입 검증 제거

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.java
+++ b/src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.java
@@ -11,8 +11,6 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.time.Duration;
@@ -25,14 +23,8 @@ public class CacheConfig {
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
-        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator
-                .builder()
-                .allowIfSubType(Object.class)
-                .build();
-
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL);
 
         GenericJackson2JsonRedisSerializer redisSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
 


### PR DESCRIPTION
### Description

Redis 캐시 설정에서 기본 다형성 타입 검증기(BasicPolymorphicTypeValidator)와 관련된 코드를 제거하여 코드의 간결성을 높였습니다. 이를 통해 캐시 설정의 가독성을 개선하고, 불필요한 의존성을 줄였습니다.
This pull request simplifies the `CacheConfig` class by removing unnecessary polymorphic type validation and related configurations. The changes streamline the setup of the `ObjectMapper` used for Redis serialization.

Code simplification in `CacheConfig`:

* Removed the import statements for `BasicPolymorphicTypeValidator` and `PolymorphicTypeValidator`, as they are no longer used. (`src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.java`, [src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.javaL14-L15](diffhunk://#diff-2361b588851c8735a8bc910a3c341e1a24a9bffd6784a0fa07eed159a49da6b3L14-L15))
* Eliminated the creation and configuration of the `PolymorphicTypeValidator` (`ptv`) and the activation of default typing in the `ObjectMapper`. This reduces complexity and potential security risks related to polymorphic deserialization. (`src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.java`, [src/main/java/com/luckeat/luckeatbackend/config/CacheConfig.javaL28-L35](diffhunk://#diff-2361b588851c8735a8bc910a3c341e1a24a9bffd6784a0fa07eed159a49da6b3L28-L35))


### Related Issues

<!--
  관련된 이슈 번호를 참고하세요.
  예: Fixes #123, Closes #456
-->

- Resolves #262

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

