### PR TITLE
fix(StoreController): Update performance test

### DIFF
--- a/src/main/java/com/luckeat/luckeatbackend/security/SecurityConfig.java
+++ b/src/main/java/com/luckeat/luckeatbackend/security/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/stores").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/v1/stores/{store_id:[0-9]+}").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/v1/stores/test/performance-test").permitAll()
 				.requestMatchers("/s/**").permitAll()
 				.requestMatchers("/error").permitAll()
 				// 인증 필요 엔드포인트

--- a/src/main/java/com/luckeat/luckeatbackend/security/SecurityConfig.java
+++ b/src/main/java/com/luckeat/luckeatbackend/security/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/users/register").permitAll()
 				.requestMatchers("/api/metrics-test/**").permitAll() // 메트릭 테스트 엔드포인트 허용
 				.requestMatchers(HttpMethod.GET, "/api/v1/categories/**").permitAll()
-				.requestMatchers(HttpMethod.GET, "/api/v1/stores/**").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/v1/stores").permitAll()
+				.requestMatchers(HttpMethod.GET, "/api/v1/stores/{store_id:[0-9]+}").permitAll()
 				.requestMatchers("/s/**").permitAll()
 				.requestMatchers("/error").permitAll()
 				// 인증 필요 엔드포인트

--- a/src/main/java/com/luckeat/luckeatbackend/store/controller/StoreController.java
+++ b/src/main/java/com/luckeat/luckeatbackend/store/controller/StoreController.java
@@ -108,7 +108,7 @@ public class StoreController {
 			@Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size,
 			@Parameter(description = "카테고리") @RequestParam(defaultValue = "0") int categoryId) {
 
-		int iterations = 100;
+		int iterations = 1000;
 		Map<String, Object> results = new HashMap<>();
 		Pageable pageable = PageRequest.of(page, size, parseSortParameter(sort));
 		Page<StoreListDto> lastResultPage = null;
@@ -127,9 +127,6 @@ public class StoreController {
 				long apiEndTime = System.nanoTime();
 				dbExecutionTimes.add((apiEndTime - apiStartTime) / 1_000_000);
 				successfulDbIterations++;
-				if ((i + 1) % (iterations / 10) == 0) { // 진행 상황 로깅
-					logger.info("DB 테스트 진행 중... ({} / {})", i + 1, iterations);
-				}
 			} catch (Exception e) {
 				logger.error("DB 테스트 반복 중 오류 발생 (반복 {}): {}", i + 1, e.getMessage(), e);
 			}
@@ -171,9 +168,6 @@ public class StoreController {
 				long apiEndTime = System.nanoTime();
 				cacheExecutionTimes.add((apiEndTime - apiStartTime) / 1_000_000);
 				successfulCacheIterations++;
-				if ((i + 1) % (iterations / 10) == 0) { // 진행 상황 로깅
-					logger.info("캐시 테스트 진행 중... ({} / {})", i + 1, iterations);
-				}
 			} catch (Exception e) {
 				logger.error("캐시 테스트 반복 중 오류 발생 (반복 {}): {}", i + 1, e.getMessage(), e);
 			}

--- a/src/main/java/com/luckeat/luckeatbackend/store/service/StoreService.java
+++ b/src/main/java/com/luckeat/luckeatbackend/store/service/StoreService.java
@@ -197,13 +197,18 @@ public class StoreService {
 	 * 위치 기반 검색, 이름 검색, 할인 여부 필터링, 카테고리 필터링 기능을 제공합니다.
 	 * 캐시를 적용하여 성능을 향상시켰습니다. 조건부 캐싱을 사용하여 다양한 검색 조건에 대응합니다.
 	 *
+	 * @param bypassCache true일 경우 캐시를 사용하지 않고 DB에서 직접 조회합니다.
 	 * @return 가게 목록 검색 결과 (페이징 정보 포함)
 	 */
 	@Cacheable(value = "stores", key = "T(com.luckeat.luckeatbackend.store.service.StoreService).generateCacheKey(#sort, #isDiscountOpen, #page, #size, #categoryId)",
-			   condition = "#storeName == null && (#lat == null || #lng == null)")
+			   condition = "!#bypassCache && #storeName == null && (#lat == null || #lng == null)")
 	public StoreQueryResult getStores(Double lat, Double lng, Double radius, String sort,
-										String storeName, Boolean isDiscountOpen, int page, int size, int categoryId) {
-		
+										String storeName, Boolean isDiscountOpen, int page, int size, int categoryId, boolean bypassCache) {
+
+		if (bypassCache) {
+			logger.info("캐시 우회: DB에서 직접 가게 목록 조회 수행");
+		}
+
 		long startTime = System.currentTimeMillis(); // 쿼리 시간 측정 시작
 
 		Sort sortOrder = SortUtil.parseSortParameter(sort);


### PR DESCRIPTION

### Description

This pull request introduces significant updates to the `SecurityConfig`, `StoreController`, and `StoreService` classes, focusing on enhancing API endpoint management, improving performance testing for store searches, and adding conditional caching capabilities.


### Changes Made

### Security and Endpoint Management:
* Updated the security configuration in `SecurityConfig.java` to refine access control for store-related endpoints. Specifically, the `/api/v1/stores` endpoint and its variants (e.g., `/api/v1/stores/{store_id:[0-9]+}`) are now explicitly permitted, while the previous wildcard match for `/api/v1/stores/**` was removed.

### Performance Testing Enhancements:
* Modified the `runStoreSearchPerformanceTest` method in `StoreController.java` to separately measure performance for database (DB) queries and cache-based queries. Added logic for cache warm-up and adjusted iterations for more robust testing. Results now include P99 latency metrics for both DB and cache tests.
* Updated the API documentation for the performance test endpoint to reflect the new DB vs. cache comparison approach.

### Caching Improvements:
* Introduced a `bypassCache` parameter to the `getStores` method in `StoreService.java`. This allows bypassing the cache to force direct DB queries, enabling more flexible performance testing and debugging. Adjusted the caching condition to exclude requests with `bypassCache` set to `true`.

### Minor Code Cleanup:
* Removed unused variables and simplified logic in the performance testing code within `StoreController.java`.
* Added a minor formatting change in `StoreController.java` for better readability.

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->

